### PR TITLE
サインアップを実行して`/my-box`に遷移した後、即座に`/`に遷移してしまう不具合を修正する

### DIFF
--- a/pkgs/frontend/pages/_app.tsx
+++ b/pkgs/frontend/pages/_app.tsx
@@ -1,18 +1,18 @@
-import { GlobalProvider } from "@/context/GlobalProvider";
-import { getEnv } from "@/utils/getEnv";
+import {GlobalProvider} from "@/context/GlobalProvider";
+import {getEnv} from "@/utils/getEnv";
 import {
   RainbowKitProvider,
   darkTheme,
   getDefaultConfig,
 } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
-import type { AppProps } from "next/app";
-import { useEffect, useState } from "react";
-import { WagmiProvider } from "wagmi";
-import { polygonAmoy } from "wagmi/chains";
+import type {AppProps} from "next/app";
+import {useEffect, useMemo, useState} from "react";
+import {WagmiProvider} from "wagmi";
+import {polygonAmoy} from "wagmi/chains";
 import "../styles/globals.css";
-import { ResponseData } from "./api/env";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {ResponseData} from "./api/env";
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
 import DarkMode from "@/components/layouts/DarkMode/DarkMode";
 
 /**
@@ -22,19 +22,19 @@ import DarkMode from "@/components/layouts/DarkMode/DarkMode";
  */
 const queryClient = new QueryClient();
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({Component, pageProps}: AppProps) {
   const [env, setEnv] = useState<ResponseData>();
 
-  let wagmiConfig: any;
-
-  if (env != undefined) {
-    wagmiConfig = getDefaultConfig({
+  const wagmiConfig: any = useMemo(() =>
+    env &&
+    getDefaultConfig({
       appName: "Monas",
       // chains: process.env.NEXT_PUBLIC_ENABLE_TESTNETS ? [polygonAmoy] : [],
       chains: [polygonAmoy],
-      projectId: env.WALLET_CONNECT_PROJECT_ID!,
-    });
-  }
+      projectId: env?.WALLET_CONNECT_PROJECT_ID!,
+    }),
+    [env]
+  );
 
   useEffect(() => {
     const init = async () => {

--- a/pkgs/frontend/pages/index.tsx
+++ b/pkgs/frontend/pages/index.tsx
@@ -1,23 +1,24 @@
 import Loading from "@/components/loading";
-import { GlobalContext } from "@/context/GlobalProvider";
-import { getEnv } from "@/utils/getEnv";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { useRouter } from "next/router";
-import { useContext, useEffect, useState } from "react";
-import { filecoinCalibration } from "viem/chains";
-import { useAccount, useSignMessage } from "wagmi";
-import { ResponseData } from "./api/env";
-import { useSignUp } from "@/hooks/cryptree/useSignUp";
-import { useLogin } from "@/hooks/cryptree/useLogin";
+import {GlobalContext} from "@/context/GlobalProvider";
+import {getEnv} from "@/utils/getEnv";
+import {ConnectButton} from "@rainbow-me/rainbowkit";
+import {useRouter} from "next/router";
+import {useContext, useEffect, useState} from "react";
+import {filecoinCalibration} from "viem/chains";
+import {useAccount, useSignMessage} from "wagmi";
+import {ResponseData} from "./api/env";
+import {useSignUp} from "@/hooks/cryptree/useSignUp";
+import {useLogin} from "@/hooks/cryptree/useLogin";
 
 export default function Login() {
+  const [routePushed, setRoutePushed] = useState(false);
   const [env, setEnv] = useState<ResponseData>();
   const account = useAccount();
   const router = useRouter();
   const globalContext = useContext(GlobalContext);
-  const { data: signMessageData, signMessageAsync } = useSignMessage();
-  const { data: signUpData } = useSignUp(account?.address!, signMessageData!);
-  const { data: loginData } = useLogin(account?.address!, signMessageData!);
+  const {data: signMessageData, signMessageAsync} = useSignMessage();
+  const {data: signUpData} = useSignUp(account?.address!, signMessageData!);
+  const {data: loginData} = useLogin(account?.address!, signMessageData!);
 
   /**
    * authenticate
@@ -27,7 +28,7 @@ export default function Login() {
       globalContext.setLoading(true);
       // get .env values
       const envData = await getEnv();
-      await signMessageAsync({ message: envData.SECRET_MESSAGE });
+      await signMessageAsync({message: envData.SECRET_MESSAGE});
     } catch (err) {
       console.error("error:", err);
     } finally {
@@ -37,8 +38,11 @@ export default function Login() {
 
   useEffect(() => {
     console.log("signMessageData:", signMessageData);
+    console.log("routePushed:", routePushed);
     if (signMessageData) {
-      if (signUpData || loginData) {
+      if ((signUpData || loginData) && !routePushed) {
+        console.log("setRoutePushed(true)");
+        setRoutePushed(true);
         router.push("/my-box");
       }
     }
@@ -118,7 +122,7 @@ export default function Login() {
                           }
 
                           return (
-                            <div style={{ display: "flex", gap: 12 }}>
+                            <div style={{display: "flex", gap: 12}}>
                               <button onClick={authenticate} type="button">
                                 signUp/login
                               </button>


### PR DESCRIPTION
## 背景

サインアップに関係して、以下の問題が発生しています。

- サインアップの際に、`useEffect()`が複数回トリガーされることで`router.push()`が複数回呼ばれてエラーが出る
- サインアップを実行して`/my-box`に遷移した直後に`/`に戻されてしまう
  - my-box.tsx内で`wagmi#useAccount()`から`{ isConnected: false }`が返ってきているせいで、`router.push("/")`を呼び出す条件に引っ掛かってしまう https://github.com/Monas-project/Proto-Prototype/blob/226335a817aedc69e4fe5a2b0dc773b4b2b6e9b6/pkgs/frontend/pages/my-box.tsx#L427-L430
  - ↑ページ遷移のたびにwagmiの内部状態がリセットされている？

## 変更内容

- index.tsx: `router.push()`が呼ばれたかどうか記録するstate、`routePushed`を用意して、`router.push()`が複数回呼び出されるのを防ぐ
- _app.tsx: `useMemo()`を使用して、レンダリングの度に`raiboutkit#getDefaultConfig()`が新しいconfigを作成することを防ぐ（参考: https://github.com/wevm/wagmi/discussions/402 ）