### PR TITLE
Add IPFS Daemon

### DIFF
--- a/pkgs/cryptree/ec2/ipfs.service
+++ b/pkgs/cryptree/ec2/ipfs.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=IPFS Daemon
+After=network.target
+
+[Service]
+User=
+ExecStart=/usr/local/bin/ipfs daemon
+Restart=always
+RestartSec=5
+LimitNOFILE=10240
+
+[Install]
+WantedBy=multi-user.target
+

--- a/pkgs/cryptree/ec2/ipfs.service
+++ b/pkgs/cryptree/ec2/ipfs.service
@@ -11,4 +11,3 @@ LimitNOFILE=10240
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
### Summary
Add systemd service unit file for IPFS daemon management.

### Changes
- Added ipfs.service file to configure IPFS daemon under systemd.
- Set ExecStart to /usr/local/bin/ipfs daemon in the service file.
- Configured automatic restart with Restart=always and RestartSec=5.
- Included LimitNOFILE=10240 to increase the maximum number of open files.
- Specified After=network.target to ensure the service starts after the network is available.