### PR TITLE
Fix empty shared folder bug

### DIFF
--- a/pkgs/frontend/pages/my-box.tsx
+++ b/pkgs/frontend/pages/my-box.tsx
@@ -128,7 +128,7 @@ export default function MyBox() {
         {
           text: "Own Space",
           path: "/my-box",
-          cid: rootId!,
+          cid: res.root_id,
           key: rootKey!,
         },
       ]);
@@ -189,7 +189,7 @@ export default function MyBox() {
         {
           text: "Own Space",
           path: "/my-box",
-          cid: rootId!,
+          cid: res.root_id,
           key: rootKey!,
         },
       ]);
@@ -245,7 +245,7 @@ export default function MyBox() {
         {
           text: "Own Space",
           path: "/my-box",
-          cid: rootId!,
+          cid: res.root_id,
           key: rootKey!,
         },
       ]);


### PR DESCRIPTION
## Summary

Fix the bug that you cannot see anything in shared folder which there's supposed to be something.

## changes

- Set res.root_id from rootId in my-box.tsx everytime creating, uploading and deleting folder/files to show latest node info