### PR TITLE
Fix vercelignore

### DIFF
--- a/pkgs/cryptree/.vercelignore
+++ b/pkgs/cryptree/.vercelignore
@@ -1,1 +1,6 @@
 .env
+aws
+ec2
+ipfs
+docker
+__pycache__


### PR DESCRIPTION
## Summary

Add folder names into .vercelignore to avoid making source code exceeds error in deploying

